### PR TITLE
Fix camera matrix calculations.

### DIFF
--- a/.changeset/rich-dragons-greet.md
+++ b/.changeset/rich-dragons-greet.md
@@ -1,0 +1,5 @@
+---
+"react-three-map": patch
+---
+
+Fix camera matrix calculations.

--- a/src/core/use-on-add.ts
+++ b/src/core/use-on-add.ts
@@ -44,11 +44,10 @@ export function useOnAdd(ref: StateRef, { frameloop, ...renderProps }: RenderPro
 
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         state.gl.forceContextLoss = () => { };
-
-        // we update the camera on create rather than on config
-        // because otherwise some components may use it too early
-        // and get NaN values they can't recover from (drei HTML)
-        state.camera.matrixAutoUpdate = false;
+        
+      },
+      camera: {
+        matrixAutoUpdate: false,
       },
       size: {
         width: canvas.clientWidth,


### PR DESCRIPTION
Render was slightly shifted away from its intended position.

Steps: Render a box at the centre of the map.
Expected: Box should be at the centre of the map.
Previously: Box was shifted towards the north by a few meters.