### PR TITLE
revert DPR fix as it didn't work

### DIFF
--- a/.changeset/itchy-garlics-behave.md
+++ b/.changeset/itchy-garlics-behave.md
@@ -1,0 +1,5 @@
+---
+"react-three-map": patch
+---
+
+Revert 748d7a7: Fix issues on DPR or browser zoom changes.

--- a/src/core/use-on-add.ts
+++ b/src/core/use-on-add.ts
@@ -74,9 +74,15 @@ export function useOnAdd(
   })
 
   const onResize = useFunction(() => {
+    if (!r3mRef.current.map) return;
     if (!r3mRef.current.state) return;
-    // because we update size out of zustand, we just want to let it know that something changed
-    r3mRef.current.state.set({});
+    const canvas = r3mRef.current.map.getCanvas();
+    r3mRef.current.state.setSize(
+      canvas.clientWidth,
+      canvas.clientHeight,
+      false
+    );
+
   })
 
   const onRemove = useFunction(() => {

--- a/src/core/use-render.ts
+++ b/src/core/use-render.ts
@@ -11,8 +11,6 @@ export function useRender(
   const render = useFunction((_gl: WebGL2RenderingContext, mapCamMx: number[]) => {
     const r3m = r3mRef.current;
     if (!r3m.state || !r3m.map) return;
-    r3m.state.size.width = r3m.state.gl.domElement.clientWidth;
-    r3m.state.size.height = r3m.state.gl.domElement.clientHeight;
     const camera = r3m.state.camera;
     const gl = r3m.state.gl;
     const advance = r3m.state.advance;


### PR DESCRIPTION
Reverts https://github.com/RodrigoHamuy/react-three-map/pull/74

**Steps**: On any story, use Browser zoom or change DPR through DevTools by swapping between mobile and desktop view.
**Expected**: Things should work as usual.
**Previously**: Render looks weird.

I failed to noticed the issue was still happening because I tested using "HTML on top" story, which has a country-level zoom.

But the issue is more obvious on "Comparison" story, which uses a street level zoom.

I'm not even sure if this is zoom related.