### PR TITLE
fix on DPR changes

### DIFF
--- a/.changeset/serious-bananas-wink.md
+++ b/.changeset/serious-bananas-wink.md
@@ -1,0 +1,5 @@
+---
+"react-three-map": patch
+---
+
+Fix bug on DPR change.

--- a/src/core/generic-map.ts
+++ b/src/core/generic-map.ts
@@ -37,6 +37,8 @@ export interface MercatorCoordinate {
 /** Generic interface of Mapbox/Maplibre `Map` */
 export interface MapInstance {
 	getCanvas(): HTMLCanvasElement;
+	/** MapLibre only */
+	getPixelRatio?: ()=>number;
 	triggerRepaint(): void;
 	// eslint-disable-next-line @typescript-eslint/ban-types
 	on<T extends keyof MapEventType>(type: T, listener: (ev: MapEventType[T] & Object) => void): this;

--- a/src/core/use-on-add.ts
+++ b/src/core/use-on-add.ts
@@ -76,7 +76,21 @@ export function useOnAdd(
   const onResize = useFunction(() => {
     if (!r3mRef.current.map) return;
     if (!r3mRef.current.state) return;
-    const canvas = r3mRef.current.map.getCanvas();
+    const map = r3mRef.current.map;
+    const canvas = map.getCanvas();
+
+    // update DPR only on mapbox
+    let updateDPR = canvas.classList.contains('mapboxgl-canvas');
+
+    // or on newer versions of MapLibre that take this into account
+    if(!updateDPR && map.getPixelRatio && map.getPixelRatio() === window.devicePixelRatio) {
+      updateDPR = true;
+    }    
+
+    if(updateDPR) {
+      r3mRef.current.state.setDpr(window.devicePixelRatio);
+    }
+
     r3mRef.current.state.setSize(
       canvas.clientWidth,
       canvas.clientHeight,


### PR DESCRIPTION
**Steps**: On any story, use Browser zoom or change DPR through DevTools by swapping between mobile and desktop view.
**Expected**: Things should work as usual.
**Previously**: Render looks weird.

The issue is more obvious on "Comparison" story.

The issue only happens on Mapbox stories, or if you update MapLibre to newer versions.

Previously:
![image](https://github.com/RodrigoHamuy/react-three-map/assets/2405611/84e46d62-66a8-441b-991a-b3974a9037d8)

Expected:
![image](https://github.com/RodrigoHamuy/react-three-map/assets/2405611/2e149d16-667d-4a50-a281-d31a93d780ea)
