### PR TITLE
Increase latitude accuracy level

### DIFF
--- a/.changeset/giant-elephants-pull.md
+++ b/.changeset/giant-elephants-pull.md
@@ -1,0 +1,7 @@
+---
+"react-three-map": patch
+---
+
+- Improve accuracy at long distances for `coordsToVector3`.
+- Improve translation accuracy for `NearCoordinates`, but scale is still ignored.
+- Update `earthRadius` from `6378137` to `6371008.8` to match [Mapbox](https://github.com/maplibre/maplibre-gl-js/blob/8ea76118210dd18fa52fdb83f2cbdd1229807346/src/geo/lng_lat.ts#L8) and [Maplibre](https://github.com/maplibre/maplibre-gl-js/blob/main/src/geo/lng_lat.ts#L8).

--- a/README.md
+++ b/README.md
@@ -198,11 +198,11 @@ import { Canvas, Coordinates } from 'react-three-map'
 
 [![](https://img.shields.io/badge/-demo-%23ff69b4)](https://rodrigohamuy.github.io/react-three-map/?story=multi-coordinates--default)
 
-Same as `Coordinates`, but with an error margin that increases the further you are from the origin.
+Same as `Coordinates`, but scale is ignored in exchange of being able to be rendered under the same scene.
 
-Recommended to use at city level distances, but margin errors will be noticeable at country level distances.
+Works well at city level distances, but since scale remains unchanged, is not recommended at country level distances.
 
-Check the story to see the difference between the two.
+Check the story to see the difference between the two or check #102 for more info.
 
 ### useMap
 
@@ -224,7 +224,7 @@ const Component = () => {
 
 This utility function converts geographic coordinates into a `Vector3Tuple`, which represents a 3D vector in meters.
 
-Similar to `NearCoordinates` it has a relatively good precision at city distances, but is not recommended if your distances are too big.
+Similar to `NearCoordinates`, remember that this only updates positions (translation) but that scale is not taken into account, which has an important factor at very long distances (country level).
 
 
 | Parameter        | Description                                                     |
@@ -240,7 +240,9 @@ Returns a `Vector3Tuple` representing the 3D position of the point relative to t
 
 This utility function converts a `Vector3Tuple`, which represents a 3D vector in meters, back into geographic coordinates.
 
-It is the inverse of `coordsToVector3` and maintains the same level of precision. It is not recommended for use with very large distances.
+It is the inverse of `coordsToVector3` but it does not have a good level of precision at long distances since we haven't reverse engineered #102 fix yet.
+
+Recommended to use at city level distances, but margin errors will be noticeable at country level distances.
 
 | Parameter                | Description                                                     |
 | ------------------------ | --------------------------------------------------------------- |

--- a/src/api/coords-to-vector-3.ts
+++ b/src/api/coords-to-vector-3.ts
@@ -2,6 +2,32 @@ import { MathUtils, Vector3Tuple } from 'three';
 import { Coords } from './coords';
 import { earthRadius } from "../core/earth-radius";
 
+
+const mercatorScaleLookup: number[] = [];
+
+// Populate the lookup table. Using a lookup table is faster then calculating the scale for each point.
+for (let i = 0; i <= 90000; i++) {  // 0.001 degree steps
+  const lat = i * 0.001;
+  mercatorScaleLookup[i] = 1 / Math.cos(lat * MathUtils.DEG2RAD);
+}
+
+export function mercatorScale(lat: number): number {
+  const index = Math.round(lat * 1000);  // lat is rounded to nearest 0.001
+  return mercatorScaleLookup[index];
+}
+
+export function averageMercatorScale(originLat: number, pointLat: number, steps = 10): number {
+  let totalScale = 0;
+  const latStep = (pointLat - originLat) / steps;
+
+  for (let i = 0; i <= steps; i++) {
+      const lat = originLat + latStep * i;
+      const index = Math.round(lat * 1000);
+      totalScale += mercatorScaleLookup[index];
+  }
+  return totalScale / (steps + 1);
+}
+
 export function coordsToVector3(point: Coords, origin: Coords): Vector3Tuple {
   const latitudeDiff = (point.latitude - origin.latitude) * MathUtils.DEG2RAD;
   const longitudeDiff = (point.longitude - origin.longitude) * MathUtils.DEG2RAD;
@@ -9,7 +35,15 @@ export function coordsToVector3(point: Coords, origin: Coords): Vector3Tuple {
 
   const x = longitudeDiff * earthRadius * Math.cos(origin.latitude * MathUtils.DEG2RAD);
   const y = altitudeDiff;
-  const z = -latitudeDiff * earthRadius;
+  const zOld = -latitudeDiff * earthRadius;
+
+  // dynamic step size based on latitude difference. calculate the mercator unit scale at origin
+  // and the scale average along the line to the point for better accuracy far from origin
+  const steps = Math.ceil(Math.abs(point.latitude - origin.latitude)) * 100
+  const absOriginLat = Math.abs(origin.latitude); // use abs values for scale calculation (same scale for north and south)
+  const absPointLat = Math.abs(point.latitude);
+  const avgScale = averageMercatorScale(absOriginLat, absPointLat, steps);
+  const z = zOld / mercatorScale(absOriginLat) * avgScale;
 
   return [x, y, z] as Vector3Tuple;
 }

--- a/src/api/coords-to-vector-3.ts
+++ b/src/api/coords-to-vector-3.ts
@@ -39,7 +39,7 @@ export function coordsToVector3(point: Coords, origin: Coords): Vector3Tuple {
 
   // dynamic step size based on latitude difference. calculate the mercator unit scale at origin
   // and the scale average along the line to the point for better accuracy far from origin
-  const steps = Math.ceil(Math.abs(point.latitude - origin.latitude)) * 100
+  const steps = Math.ceil(Math.abs(point.latitude - origin.latitude)) * 100 + 1;
   const absOriginLat = Math.abs(origin.latitude); // use abs values for scale calculation (same scale for north and south)
   const absPointLat = Math.abs(point.latitude);
   const avgScale = averageMercatorScale(absOriginLat, absPointLat, steps);

--- a/src/api/coords-to-vector-3.ts
+++ b/src/api/coords-to-vector-3.ts
@@ -30,13 +30,12 @@ export function coordsToVector3(point: Coords, origin: Coords): Vector3Tuple {
 
   const x = longitudeDiff * earthRadius * Math.cos(origin.latitude * MathUtils.DEG2RAD);
   const y = altitudeDiff;
-  const zOld = -latitudeDiff * earthRadius;
 
   // dynamic step size based on latitude difference. calculate the mercator unit scale at origin
   // and the scale average along the line to the point for better accuracy far from origin
   const steps = Math.ceil(Math.abs(point.latitude - origin.latitude)) * 100 + 1;
   const avgScale = averageMercatorScale(origin.latitude, point.latitude, steps);
 
-  const z = (zOld / getMercatorScale(origin.latitude)) * avgScale;
+  const z = ((-latitudeDiff * earthRadius) / getMercatorScale(origin.latitude)) * avgScale;
   return [x, y, z] as Vector3Tuple;
 }

--- a/src/api/coords-to-vector-3.ts
+++ b/src/api/coords-to-vector-3.ts
@@ -35,11 +35,8 @@ export function coordsToVector3(point: Coords, origin: Coords): Vector3Tuple {
   // dynamic step size based on latitude difference. calculate the mercator unit scale at origin
   // and the scale average along the line to the point for better accuracy far from origin
   const steps = Math.ceil(Math.abs(point.latitude - origin.latitude)) * 100 + 1;
-  const absOriginLat = Math.abs(origin.latitude); // use abs values for scale calculation (same scale for north and south)
-  const absPointLat = Math.abs(point.latitude);
-  const avgScale = averageMercatorScale(absOriginLat, absPointLat, steps);
+  const avgScale = averageMercatorScale(origin.latitude, point.latitude, steps);
 
-  const z = (zOld / getMercatorScale(absOriginLat)) * avgScale;
-
+  const z = (zOld / getMercatorScale(origin.latitude)) * avgScale;
   return [x, y, z] as Vector3Tuple;
 }

--- a/src/core/earth-radius.ts
+++ b/src/core/earth-radius.ts
@@ -1,1 +1,1 @@
-export const earthRadius = 6378137;
+export const earthRadius = 6371008.8;


### PR DESCRIPTION
with this code change, the buildings 3d story has global accuracy.
previously, when drawing buildings further away from the origin, the lat component got an offset.
here i calculate the mercator factor, which represents the scale difference between the vector unit and the mercator unit.
since the background map is in mercator, we need to adapt the change in this unit factor with increasing latitude.

the simple way is to have the mean factor between origin and point "(originFactor + pointFactor) / 2" . But this relation is not linear, so it does not scale well to larger distances. 
To mitigate this, i calculate the factor for different steps on the latitude from origin towards the point and take an average of this list. 
For performance reasons, there is a precalculated lookup list.
This step adds about 20% computational overhead to the draw of the buildings, but it makes the buildings match the background layers even if you are hundreds of kilometers away from the origin.

i also updated the earthRadius to the one maplibre uses, this further increases the accuracy of the placement.
https://github.com/maplibre/maplibre-gl-js/blob/8ea76118210dd18fa52fdb83f2cbdd1229807346/src/geo/lng_lat.ts#L8 