### PR TITLE
Update canvas-portal.tsx

### DIFF
--- a/.changeset/thin-adults-arrive.md
+++ b/.changeset/thin-adults-arrive.md
@@ -1,0 +1,5 @@
+---
+"react-three-map": patch
+---
+
+Fix `overlay` camera calculations bug introduced by `three=>r166`.

--- a/.changeset/thin-adults-arrive.md
+++ b/.changeset/thin-adults-arrive.md
@@ -2,4 +2,4 @@
 "react-three-map": patch
 ---
 
-Fix `overlay` camera calculations bug introduced by `three=>r166`.
+Fix `overlay` camera calculations bug introduced by `three=>r166`. More info in [#143](https://github.com/RodrigoHamuy/react-three-map/issues/143).

--- a/src/core/canvas-overlay/canvas-portal.tsx
+++ b/src/core/canvas-overlay/canvas-portal.tsx
@@ -30,8 +30,8 @@ export const CanvasPortal = memo<CanvasPortalProps>(({
 
   return <Canvas
     camera={{
-      matrixAutoUpdate: false,
-      matrixWorldAutoUpdate: false,
+      matrixAutoUpdate: true,
+      matrixWorldAutoUpdate: true,
     }}
     events={events}
     eventSource={eventSource}

--- a/src/core/canvas-overlay/canvas-portal.tsx
+++ b/src/core/canvas-overlay/canvas-portal.tsx
@@ -29,10 +29,6 @@ export const CanvasPortal = memo<CanvasPortalProps>(({
   })
 
   return <Canvas
-    camera={{
-      matrixAutoUpdate: true,
-      matrixWorldAutoUpdate: true,
-    }}
     events={events}
     eventSource={eventSource}
     {...props}


### PR DESCRIPTION
setting the cameras `matrixAutoUpdate` and ` matrixWorldAutoUpdate` to `true` in `canvas-portal.tsx` enables object matrices in the `overlay` layer to be computed correctly, allowing compatibility with three.js version 166 and above.

*Note:* this has not yet been backward compatibility tested for use with three.js r165